### PR TITLE
Adding sitemap plugin for better search engine indexing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,8 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
-future: true  
+  - jekyll-sitemap
+future: true
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
Added a line to `_config.yml` to add a sitemap plugin
supported by Github Pages. I believe I have to run `jekyll build`
to get this installed. But I'll do that after I commit.

Also checked to see if the Github Pages gem was up to date by
running `gem update github-pages`. Got the following response:

```
$ gem update github-pages
Updating installed gems
Nothing to update

```
References Issue #11 and Issue #43.